### PR TITLE
[GitHub Action] Downgrade unsplash/comment-on-pr to 1.3.0

### DIFF
--- a/.github/workflows/check-and-preview.yml
+++ b/.github/workflows/check-and-preview.yml
@@ -32,7 +32,7 @@ jobs:
           args: preview
 
       - name: Comment diff on PR
-        uses: unsplash/comment-on-pr@v1.3.1
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
1.3.1 causes failure.