### PR TITLE
Switch to my own Action, which uses an updated Docker image

### DIFF
--- a/.github/workflows/check-and-preview.yml
+++ b/.github/workflows/check-and-preview.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: DNSControl check
-        uses: koenrh/dnscontrol-action@v3
+        uses: wblondel/dnscontrol-action@v3.15.0
         with:
           args: check
 
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: DNSControl preview
-        uses: koenrh/dnscontrol-action@v3
+        uses: wblondel/dnscontrol-action@v3.15.0
         id: dnscontrol_preview
         with:
           args: preview

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: DNSControl push
-        uses: koenrh/dnscontrol-action@v3
+        uses: wblondel/dnscontrol-action@v3.15.0
         with:
           args: push


### PR DESCRIPTION
jauderho builds multi-platform images an hour after upstream release and rebuilds them at least once a week: https://hub.docker.com/r/jauderho/dnscontrol

I'm switching to my own GitHub Action, which uses these images.