### PR TITLE
Map williamblondel.fr to Hashnode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL = help
 SHELL = /usr/bin/env bash
 
-DNSCONTROL_DOCKER_IMAGE = ghcr.io/stackexchange/dnscontrol:latest
+DNSCONTROL_DOCKER_IMAGE = ghcr.io/stackexchange/dnscontrol:4.8.1
 DNSCONTROL_VOLUME = "$$(pwd):/dns"
 
 .PHONY: version # Get the version of DNSControl

--- a/domains/williamblondel.fr.js
+++ b/domains/williamblondel.fr.js
@@ -1,10 +1,9 @@
 D('williamblondel.fr', REG_OVH, DnsProvider(DSP_DESEC),
-    WEB_SERVER_APEX,
+    UseHashnodeFor('@', true),
+    
     WEB_SERVER_SUBDOMAIN,
     I_AM_PIGEON_MAIL_SERVER,
     UsePigeonMailServerFor('einstein'),
-    
-    CNAME('www', '@'),
 
     // Fly.io IPs
     A('actes', '66.241.125.129'), // shared

--- a/globals/macros/use_hashnode_for.js
+++ b/globals/macros/use_hashnode_for.js
@@ -1,0 +1,26 @@
+/**
+ * Create records to map a domain to Hashnode.
+ * The function supports sub-domains.
+ * 
+ * @param {string} host 
+ * @param {boolean} withWww
+ */
+function UseHashnodeFor(host, withWww) {
+    var buildHost = function (firstString, secondString) {
+        if (secondString === '@') {
+            return firstString;
+        }
+
+        return firstString + '.' + secondString;
+    }
+
+    /* 
+     * No AAAA record because Vercel, which hosts Hashnode, doesn't support IPv6 yet
+     * https://github.com/orgs/vercel/discussions/47
+     * ETA is Q1 2024
+     */
+    return [
+        A(host, '76.76.21.21'),
+        withWww ? CNAME(buildHost('www', host), 'hashnode.network.') : null,     
+    ].filter(Boolean)
+};


### PR DESCRIPTION
My blog will be hosted on Hashnode. This PR map williamblondel.fr to Hashnode.
I also made a small change on the Makefile, so that the same version of dnscontrol is used everywhere. Dependabot will be configured to automatically update it.

I deleted the CAA records, but I will create them again once I know the CAs used by Hashnode.