### PR TITLE
Add Fly.io IPs to domains

### DIFF
--- a/domains/nocontexthumans.com.js
+++ b/domains/nocontexthumans.com.js
@@ -1,6 +1,8 @@
 // TODO: develop provider for registrar https://www.spaceship.com
 D('nocontexthumans.com', REG_NONE, DnsProvider(DSP_DESEC),
-    // HTTP
+    // HTTP: Fly.io IPs
+    A('@', '66.241.124.243'), // shared
+    AAAA('@', '2a09:8280:1::4e:f3c1'), // dedicated
     CNAME('www', '@'),
 
     // Configure emails

--- a/domains/williamblondel.com.js
+++ b/domains/williamblondel.com.js
@@ -1,6 +1,8 @@
 // TODO: develop provider for registrar https://www.spaceship.com
 D('williamblondel.com', REG_NONE, DnsProvider(DSP_DESEC),
-    // HTTP
+    // HTTP: Fly.io IPs
+    A('@', '66.241.124.243'), // shared
+    AAAA('@', '2a09:8280:1::4e:f3c1'), // dedicated
     CNAME('www', '@'),
 
     // Configure emails

--- a/domains/williamblondel.me.js
+++ b/domains/williamblondel.me.js
@@ -1,6 +1,8 @@
 // TODO: develop provider for https://www.spaceship.com
 D('williamblondel.me', REG_NONE, DnsProvider(DSP_DESEC),
-    // HTTP
+    // HTTP: Fly.io IPs
+    A('@', '66.241.124.243'), // shared
+    AAAA('@', '2a09:8280:1::4e:f3c1'), // dedicated
     CNAME('www', '@'),
 
     // Configure emails

--- a/domains/williamgeraldblondel.com.js
+++ b/domains/williamgeraldblondel.com.js
@@ -1,6 +1,8 @@
 // TODO: develop provider for registrar https://www.spaceship.com
 D('williamgeraldblondel.com', REG_NONE, DnsProvider(DSP_DESEC),
-    // HTTP
+    // HTTP: Fly.io IPs
+    A('@', '66.241.124.243'), // shared
+    AAAA('@', '2a09:8280:1::4e:f3c1'), // dedicated
     CNAME('www', '@'),
 
     // Configure emails


### PR DESCRIPTION
Since I got rid of my Contabo web server, and since Hashnode doesn't support putting multiple domains for a single blog, I create an app on fly.io that handles the redirections.