### PR TITLE
Use repository secrets instead of environment secrets for check and preview jobs

### DIFF
--- a/.github/workflows/check-and-preview.yml
+++ b/.github/workflows/check-and-preview.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.actor!= 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: DNSControl check
         uses: wblondel/dnscontrol-action@v4.8.2
@@ -17,7 +17,6 @@ jobs:
   preview:
     if: github.actor!= 'dependabot[bot]'
     runs-on: ubuntu-latest
-    environment: production
     env:
       DESEC_API_TOKEN: ${{ secrets.DESEC_API_TOKEN }}
       OVH_APP_KEY: ${{ secrets.OVH_APP_KEY }}
@@ -26,7 +25,7 @@ jobs:
     needs: check
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: DNSControl preview
         uses: wblondel/dnscontrol-action@v4.8.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-    environment: production
     env:
       DESEC_API_TOKEN: ${{ secrets.DESEC_API_TOKEN }}
       OVH_APP_KEY: ${{ secrets.OVH_APP_KEY }}
@@ -16,7 +15,7 @@ jobs:
       OVH_CONSUMER_KEY: ${{ secrets.OVH_CONSUMER_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: DNSControl push
         uses: wblondel/dnscontrol-action@v4.8.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
+    environment: production
     env:
       DESEC_API_TOKEN: ${{ secrets.DESEC_API_TOKEN }}
       OVH_APP_KEY: ${{ secrets.OVH_APP_KEY }}


### PR DESCRIPTION
I don't like that GItHub says "@wblondel temporarily deployed to production" when the `check` and `preview` jobs were executed on a PR.

In this PR I make these jobs use repository secrets instead of the production environment secrets.

The `push` job still uses the production environment.