### PR TITLE
build: remove production environment as there is only one env anyway

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-    environment: production
     env:
       DESEC_API_TOKEN: ${{ secrets.DESEC_API_TOKEN }}
       OVH_APP_KEY: ${{ secrets.OVH_APP_KEY }}


### PR DESCRIPTION
I used to have both environment secrets (for production environment) and repository secrets. 

I removed the production environment and modified the actions so that they both use the repository secrets.