### PR TITLE
chore: add target to execute dnscontrol write-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ ifndef DNSCONTROL_LOCAL_CREDS
 endif
 	@docker compose run --rm dnscontrol preview --creds $(DNSCONTROL_LOCAL_CREDS)
 
+.PHONY: write-types
+write-types:
+	@docker compose run --rm dnscontrol write-types
+
 .PHONY: help # List available commands
 help:
 	@echo "Available commands:"


### PR DESCRIPTION
Add a `write-types` Makefile target so that one can run `make write-types`to update the `types-dnscontrol.d.ts` file.